### PR TITLE
feat(auth): add OTP verification and password reset flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,8 @@ import QRScanner from "./components/auth/QRScanner";
 import Dashboard from "./pages/Dashboard";
 import PrivateRoute from "./components/routes/PrivateRoute";
 import ForgotPassword from "./components/auth/ForgotPassword";
-
+import VerifyOTP from "./components/auth/VerifyOTP";
+import ResetPassword from "./components/auth/ResetPassword";
 const App: React.FC = () => {
   return (
     <Router>
@@ -23,6 +24,8 @@ const App: React.FC = () => {
           }
         />
         <Route path="/forgot-password" element={<ForgotPassword />} />
+        <Route path="/verify-otp" element={<VerifyOTP />} />
+        <Route path="/reset-password" element={<ResetPassword />} />
       </Routes>
     </Router>
   );

--- a/src/api/API.ts
+++ b/src/api/API.ts
@@ -411,7 +411,9 @@ export const checkUsedPhone = async (
   phone: string
 ): Promise<{ otpId: string; otp: string }> => {
   try {
-    const response = await apiClient.get(`/api/auth/check-used-phone/${phone}`);
+    const response = await apiClient.post(
+      `/api/auth/check-used-phone/${phone}`
+    );
     return {
       otpId: response.data.otpId,
       otp: response.data.otp,
@@ -423,6 +425,87 @@ export const checkUsedPhone = async (
       );
     }
     throw new Error("Không thể kiểm tra số điện thoại");
+  }
+};
+// Gửi mã Xác thực OTP
+export const sendOTPForgotPassword = async (
+  phone: string
+): Promise<{ otpId: string }> => {
+  try {
+    const response = await apiClient.post(
+      "/api/auth/send-otp-forgot-password",
+      {
+        phone,
+      }
+    );
+
+    return {
+      otpId: response.data.otpId,
+    };
+  } catch (error: unknown) {
+    if (error instanceof AxiosError) {
+      if (error.response?.status === 404) {
+        throw new Error("Không tìm thấy tài khoản với số điện thoại này");
+      }
+      throw new Error(error.response?.data?.message || "Không thể gửi mã OTP");
+    }
+    throw new Error("Không thể gửi mã OTP");
+  }
+};
+//Xác thực OTP
+export const verifyOTPForgotPassword = async (
+  phone: string,
+  otp: string,
+  otpId: string
+): Promise<void> => {
+  try {
+    const response = await apiClient.post(
+      "/api/auth/verify-otp-forgot-password",
+      {
+        phone,
+        otp,
+        otpId,
+      }
+    );
+
+    if (response.status !== 200) {
+      throw new Error("Xác thực OTP thất bại");
+    }
+  } catch (error: unknown) {
+    if (error instanceof AxiosError) {
+      if (error.response?.status === 404) {
+        throw new Error("Không tìm thấy mã OTP hợp lệ");
+      }
+      throw new Error(error.response?.data?.message || "Xác thực OTP thất bại");
+    }
+    throw new Error("Xác thực OTP thất bại");
+  }
+};
+
+//Quên mật khẩu
+export const forgotPassword = async (
+  phone: string,
+  newPassword: string
+): Promise<void> => {
+  try {
+    const response = await apiClient.put("/api/auth/forgot-password", {
+      phone,
+      newPassword,
+    });
+
+    if (response.status !== 200) {
+      throw new Error("Không thể đặt lại mật khẩu");
+    }
+  } catch (error: unknown) {
+    if (error instanceof AxiosError) {
+      if (error.response?.status === 404) {
+        throw new Error("Không tìm thấy tài khoản với số điện thoại này");
+      }
+      throw new Error(
+        error.response?.data?.message || "Không thể đặt lại mật khẩu"
+      );
+    }
+    throw new Error("Không thể đặt lại mật khẩu");
   }
 };
 

--- a/src/components/auth/ResetPassword.tsx
+++ b/src/components/auth/ResetPassword.tsx
@@ -1,0 +1,103 @@
+import React, { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+import { forgotPassword } from "../../api/API";
+
+const ResetPassword: React.FC = () => {
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [message, setMessage] = useState("");
+  const [messageType, setMessageType] = useState<"success" | "error">("success");
+  
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { phoneNumber } = location.state || {};
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!newPassword || newPassword.length < 6) {
+      setMessage("Mật khẩu phải có ít nhất 6 ký tự");
+      setMessageType("error");
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setMessage("Mật khẩu xác nhận không khớp");
+      setMessageType("error");
+      return;
+    }
+
+    try {
+      await forgotPassword(phoneNumber, newPassword);
+      setMessage("Đặt lại mật khẩu thành công!");
+      setMessageType("success");
+      setTimeout(() => {
+        navigate("/");
+      }, 2000);
+    } catch (error) {
+      if (error instanceof Error) {
+        setMessage(error.message);
+      } else {
+        setMessage("Có lỗi xảy ra. Vui lòng thử lại.");
+      }
+      setMessageType("error");
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-[#e4f4ff] p-6">
+      <div className="w-full max-w-sm rounded-lg bg-white p-8 shadow-lg">
+        <h2 className="text-3xl font-bold text-[#0066ff] text-center">SOPHY</h2>
+        <p className="mt-2 text-lg text-[#666666] text-center">
+          Đặt lại mật khẩu
+        </p>
+
+        <form onSubmit={handleSubmit} className="mt-6 space-y-6">
+          <div>
+            <label className="block text-sm font-medium text-gray-900">
+              Mật khẩu mới
+            </label>
+            <input
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              className="mt-2 w-full rounded-md border border-[#e0e0e0] px-3 py-2 focus:border-[#0066ff] focus:outline-none"
+              placeholder="Nhập mật khẩu mới"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-900">
+              Xác nhận mật khẩu
+            </label>
+            <input
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              className="mt-2 w-full rounded-md border border-[#e0e0e0] px-3 py-2 focus:border-[#0066ff] focus:outline-none"
+              placeholder="Nhập lại mật khẩu mới"
+            />
+          </div>
+
+          {message && (
+            <div
+              className={`text-sm text-center ${
+                messageType === "success" ? "text-green-500" : "text-red-500"
+              }`}>
+              {message}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            className="w-full rounded-md bg-[#0066ff] px-4 py-2 text-sm font-semibold text-white hover:bg-[#0051cc] focus:outline-none focus:ring-2 focus:ring-[#0066ff] focus:ring-offset-2">
+            Xác nhận
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ResetPassword;

--- a/src/components/auth/VerifyOTP.tsx
+++ b/src/components/auth/VerifyOTP.tsx
@@ -1,0 +1,123 @@
+import React, { useState } from "react";
+import { useLocation, useNavigate, Link } from "react-router-dom";
+import { sendOTPForgotPassword, verifyOTPForgotPassword } from "../../api/API";
+
+const VerifyOTP: React.FC = () => {
+  const [otp, setOtp] = useState("");
+  const [message, setMessage] = useState("");
+  const [messageType, setMessageType] = useState<"success" | "error">(
+    "success"
+  );
+  const [isResending, setIsResending] = useState(false);
+
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { phoneNumber, otpId } = location.state || {};
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!otp || otp.length !== 6) {
+      setMessage("Vui lòng nhập mã OTP hợp lệ");
+      setMessageType("error");
+      return;
+    }
+
+    try {
+      await verifyOTPForgotPassword(phoneNumber, otp, otpId);
+      setMessage("Xác thực OTP thành công!");
+      setMessageType("success");
+
+      setTimeout(() => {
+        navigate("/reset-password", {
+          state: {
+            phoneNumber,
+            verified: true,
+          },
+        });
+      }, 2000);
+    } catch (error) {
+      if (error instanceof Error) {
+        setMessage(error.message);
+      } else {
+        setMessage("Có lỗi xảy ra. Vui lòng thử lại.");
+      }
+      setMessageType("error");
+    }
+  };
+
+  const handleResendOTP = async () => {
+    try {
+      setIsResending(true);
+      await sendOTPForgotPassword(phoneNumber);
+      setMessage("Đã gửi lại mã OTP!");
+      setMessageType("success");
+    } catch (error) {
+      if (error instanceof Error) {
+        setMessage(error.message);
+      } else {
+        setMessage("Không thể gửi lại mã OTP. Vui lòng thử lại sau.");
+      }
+      setMessageType("error");
+    } finally {
+      setIsResending(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-[#e4f4ff] p-6">
+      <div className="w-full max-w-sm rounded-lg bg-white p-8 shadow-lg">
+        <h2 className="text-3xl font-bold text-[#0066ff] text-center">SOPHY</h2>
+        <p className="mt-2 text-lg text-[#666666] text-center">Xác thực OTP</p>
+
+        <form onSubmit={handleSubmit} className="mt-6 space-y-6">
+          <div>
+            <label className="block text-sm font-medium text-gray-900">
+              Nhập mã OTP
+            </label>
+            <input
+              type="text"
+              value={otp}
+              onChange={(e) => setOtp(e.target.value)}
+              maxLength={6}
+              className="mt-2 w-full rounded-md border border-[#e0e0e0] px-3 py-2 focus:border-[#0066ff] focus:outline-none"
+              placeholder="Nhập mã OTP 6 số"
+            />
+            <button
+              type="button"
+              onClick={handleResendOTP}
+              disabled={isResending}
+              className="mt-2 text-sm text-[#0066ff] hover:underline">
+              {isResending ? "Đang gửi..." : "Gửi lại mã"}
+            </button>
+          </div>
+
+          {message && (
+            <div
+              className={`text-sm text-center ${
+                messageType === "success" ? "text-green-500" : "text-red-500"
+              }`}>
+              {message}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            className="w-full rounded-md bg-[#0066ff] px-4 py-2 text-sm font-semibold text-white hover:bg-[#0051cc] focus:outline-none focus:ring-2 focus:ring-[#0066ff] focus:ring-offset-2">
+            Xác nhận
+          </button>
+        </form>
+
+        <div className="mt-4 text-center">
+          <Link
+            to="/forgot-password"
+            className="text-sm text-[#0066ff] hover:underline">
+            Quay lại
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default VerifyOTP;

--- a/src/components/content/modal/SettingsModal.tsx
+++ b/src/components/content/modal/SettingsModal.tsx
@@ -1,24 +1,60 @@
-import { Modal } from "antd";
+import { Modal, Radio, Select } from "antd";
+import { useState } from "react";
 
 const SettingsModal: React.FC<{ visible: boolean; onClose: () => void }> = ({
   visible,
   onClose,
 }) => {
+  const [contactDisplay, setContactDisplay] = useState("active");
+  const [language, setLanguage] = useState("vi");
+
   return (
     <Modal
-      title="Cài đặt"
-      open={visible} // Use `open` instead of `visible` in Ant Design v4+
+      title={
+        <div className="flex items-center">
+          <span className="text-lg font-semibold">Cài đặt</span>
+        </div>
+      }
+      open={visible}
       onCancel={onClose}
       footer={null}
-      width={{
-        xs: "90%",
-        sm: "80%",
-        md: "70%",
-        lg: "60%",
-        xl: "50%",
-        xxl: "40%",
-      }}>
-      <p>Content of the modal</p>
+      width={600}
+      className="settings-modal"
+    >
+      <div className="space-y-6 p-4">
+        {/* Danh bạ section */}
+        <div>
+          <h3 className="text-base font-medium mb-2">Danh bạ</h3>
+          <p className="text-sm text-gray-500 mb-4">
+            Danh sách bạn bè được hiển thị trong danh bạ
+          </p>
+          <Radio.Group 
+            value={contactDisplay} 
+            onChange={(e) => setContactDisplay(e.target.value)}
+            className="flex flex-col space-y-2"
+          >
+            <Radio value="all">Hiển thị tất cả bạn bè</Radio>
+            <Radio value="active">Chỉ hiển thị bạn bè đang sử dụng Sophy</Radio>
+          </Radio.Group>
+        </div>
+
+        {/* Ngôn ngữ section */}
+        <div>
+          <h3 className="text-base font-medium mb-2">Ngôn ngữ</h3>
+          <div className="flex items-center space-x-4">
+            <span className="text-sm">Thay đổi ngôn ngữ</span>
+            <Select
+              value={language}
+              onChange={(value) => setLanguage(value)}
+              style={{ width: 120 }}
+              options={[
+                { value: 'vi', label: 'Tiếng Việt' },
+                { value: 'en', label: 'English' },
+              ]}
+            />
+          </div>
+        </div>
+      </div>
     </Modal>
   );
 };

--- a/src/components/content/modal/UserModal.tsx
+++ b/src/components/content/modal/UserModal.tsx
@@ -69,7 +69,18 @@ const UserModal: React.FC<UserModalProps> = ({ isOpen, onClose }) => {
         bodyStyle={{ padding: "24px" }}
       >
         <div className="text-center mt-4">
-          <div className="flex justify-baseline -mt-12">
+          {/* Add background banner */}
+          <div 
+            className="absolute top-0 left-0 right-0 h-32 bg-gradient-to-r from-blue-400 to-blue-600 rounded-t-lg"
+            style={{
+              backgroundImage: `url(${ 'https://picsum.photos/id/1/800/200'})`,
+              // user?.urlbanner ||
+              backgroundSize: 'cover',
+              backgroundPosition: 'center',
+            }}
+          />
+          
+          <div className="flex justify-baseline mt-5 relative">
             <img
               src={user?.urlavatar || "https://picsum.photos/id/1/200/200"}
               alt="Avatar"
@@ -80,7 +91,7 @@ const UserModal: React.FC<UserModalProps> = ({ isOpen, onClose }) => {
               <span className="ml-2 text-gray-500 hover:text-gray-700 cursor-pointer">
                 <FaMarker
                   onClick={() => {
-                    setIsEditModalOpen(true); // Open the EditUserModal
+                    setIsEditModalOpen(true);
                   }}
                 />
               </span>


### PR DESCRIPTION
This commit introduces new components and API endpoints for OTP verification and password reset functionality. It includes:
- `VerifyOTP` and `ResetPassword` components for handling OTP verification and password reset.
- New API methods (`sendOTPForgotPassword`, `verifyOTPForgotPassword`, `forgotPassword`) for managing the OTP and password reset process.
- Updated `ForgotPassword` component to integrate with the new OTP flow.
- Added routes for `/verify-otp` and `/reset-password` in `App.tsx`.