### PR TITLE
feat(chat): add modals for label, notification, and auto-delete settings

### DIFF
--- a/src/components/chat/ChatList.tsx
+++ b/src/components/chat/ChatList.tsx
@@ -9,6 +9,9 @@ import ErrorBoundary from "../common/ErrorBoundary";
 import { formatMessageTime } from "../../utils/dateUtils";
 import ChatNav from "./ChatNav";
 import GroupAvatar from "./GroupAvatar";
+import LabelModal from "./modals/LabelModal";
+import NotificationModal from "./modals/NotificationModal";
+import AutoDeleteModal from "./modals/AutoDeleteModal";
 
 import { Conversation } from "../../features/chat/types/conversationTypes";
 
@@ -17,8 +20,15 @@ interface ChatListProps {
 }
 
 const ChatList: React.FC<ChatListProps> = ({ onSelectConversation }) => {
-  const { conversations, userCache, displayNames, userAvatars } = useConversations();
+  const { conversations, userCache, displayNames, userAvatars } =
+    useConversations();
   const [activeMenu, setActiveMenu] = useState<string | null>(null);
+  const [selectedConversation, setSelectedConversation] = useState<
+    string | null
+  >(null);
+  const [isLabelModalOpen, setIsLabelModalOpen] = useState(false);
+  const [isNotificationModalOpen, setIsNotificationModalOpen] = useState(false);
+  const [isAutoDeleteModalOpen, setIsAutoDeleteModalOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
@@ -34,9 +44,9 @@ const ChatList: React.FC<ChatListProps> = ({ onSelectConversation }) => {
       }
     };
 
-    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener("mousedown", handleClickOutside);
     return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener("mousedown", handleClickOutside);
     };
   }, []);
 
@@ -82,7 +92,8 @@ const ChatList: React.FC<ChatListProps> = ({ onSelectConversation }) => {
                 </span>
                 <div className="flex items-center">
                   <span className="text-xs text-gray-500 group-hover:opacity-0 transition-opacity duration-200">
-                    {chat.lastMessage && formatMessageTime(chat.lastMessage.createdAt)}
+                    {chat.lastMessage &&
+                      formatMessageTime(chat.lastMessage.createdAt)}
                   </span>
                   <div className="absolute right-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
                     <button
@@ -91,66 +102,75 @@ const ChatList: React.FC<ChatListProps> = ({ onSelectConversation }) => {
                       title="Thêm"
                       onClick={(e) => {
                         e.stopPropagation();
-                        setActiveMenu(activeMenu === chat.conversationId ? null : chat.conversationId);
+                        setActiveMenu(
+                          activeMenu === chat.conversationId
+                            ? null
+                            : chat.conversationId
+                        );
                       }}
                     >
-                      <FontAwesomeIcon icon={faEllipsisH} className="fa fa-ellipsis-h text-gray-600" />
+                      <FontAwesomeIcon
+                        icon={faEllipsisH}
+                        className="fa fa-ellipsis-h text-gray-600"
+                      />
                     </button>
                     <div
                       ref={menuRef}
-                      className={`absolute z-20 w-50 bg-white shadow-lg rounded-md border border-gray-200 right-0 mt-1 ${activeMenu === chat.conversationId ? 'block' : 'hidden'}`}
+                      className={`absolute z-20 w-50 bg-white shadow-lg rounded-md border border-gray-200 right-0 mt-1 ${activeMenu === chat.conversationId ? "block" : "hidden"}`}
                     >
                       <div className="py-1">
                         <div className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer">
                           Ghim hội thoại
                         </div>
                         <div className="border-t border-gray-200"></div>
-                        <div className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer relative group/sub flex items-center justify-between">
+                        <div
+                          className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer flex items-center justify-between"
+                          onClick={() => {
+                            setSelectedConversation(chat.conversationId);
+                            setIsLabelModalOpen(true);
+                            setActiveMenu(null);
+                          }}
+                        >
                           <span>Phân loại</span>
-                          <FontAwesomeIcon icon={faChevronRight} className="text-gray-400 ml-2" />
-                          <div className="absolute hidden group-hover/sub:block left-full top-0 w-64 bg-white shadow-lg rounded-md border border-gray-200">
-                            <div className="py-1">
-                              <div className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer">Khách hàng</div>
-                              <div className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer">Gia đình</div>
-                              <div className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer">Công việc</div>
-                              <div className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer">Bạn bè</div>
-                              <div className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer">Trả lời sau</div>
-                              <div className="border-t border-gray-200"></div>
-                              <div className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer">Quản lý thẻ phân loại</div>
-                            </div>
-                          </div>
+                          <FontAwesomeIcon
+                            icon={faChevronRight}
+                            className="ml-1"
+                          />
                         </div>
                         <div className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer">
                           Đánh dấu chưa đọc
                         </div>
                         <div className="border-t border-gray-200"></div>
-                        <div className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer relative group/sub flex items-center justify-between">
+                        <div
+                          className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer flex items-center justify-between"
+                          onClick={() => {
+                            setSelectedConversation(chat.conversationId);
+                            setIsNotificationModalOpen(true);
+                            setActiveMenu(null);
+                          }}
+                        >
                           <span>Tắt thông báo</span>
-                          <FontAwesomeIcon icon={faChevronRight} className="text-gray-400 ml-2" />
-                          <div className="absolute hidden group-hover/sub:block left-full top-0 w-64 bg-white shadow-lg rounded-md border border-gray-200">
-                            <div className="py-1">
-                              <div className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer">Trong 1 giờ</div>
-                              <div className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer">Trong 4 giờ</div>
-                              <div className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer">Cho đến 8:00 AM</div>
-                              <div className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer">Cho đến khi được mở lại</div>
-                            </div>
-                          </div>
+                          <FontAwesomeIcon
+                            icon={faChevronRight}
+                            className="ml-1"
+                          />
                         </div>
-                        <div className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer">
+                        <div className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer flex items-center justify-between">
                           Ẩn trò chuyện
                         </div>
-                        <div className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer relative group/sub flex items-center justify-between">
+                        <div
+                          className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer flex items-center justify-between"
+                          onClick={() => {
+                            setSelectedConversation(chat.conversationId);
+                            setIsAutoDeleteModalOpen(true);
+                            setActiveMenu(null);
+                          }}
+                        >
                           <span>Tin nhắn tự xóa</span>
-                          <FontAwesomeIcon icon={faChevronRight} className="text-gray-400 ml-2" />
-                          <div className="absolute hidden group-hover/sub:block left-full top-0 w-64 bg-white shadow-lg rounded-md border border-gray-200">
-                            <div className="py-1">
-                              <div className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer">1 ngày</div>
-                              <div className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer">7 ngày</div>
-                              <div className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer">14 ngày</div>
-                              <div className="border-t border-gray-200"></div>
-                              <div className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer">Không bao giờ</div>
-                            </div>
-                          </div>
+                          <FontAwesomeIcon
+                            icon={faChevronRight}
+                            className="ml-1"
+                          />
                         </div>
                         <div className="border-t border-gray-200"></div>
                         <div className="px-4 py-2 text-sm text-red-500 hover:bg-gray-100 cursor-pointer">
@@ -191,6 +211,68 @@ const ChatList: React.FC<ChatListProps> = ({ onSelectConversation }) => {
               Không có hội thoại nào
             </div>
           ),
+        }}
+      />
+
+      {/* Modals */}
+      <LabelModal
+        isOpen={isLabelModalOpen}
+        onClose={() => setIsLabelModalOpen(false)}
+        labels={[
+          {
+            id: "customer",
+            name: "Khách hàng",
+            color: "#FF6B6B",
+            selected: false,
+          },
+          { id: "family", name: "Gia đình", color: "#4ECDC4", selected: false },
+          { id: "work", name: "Công việc", color: "#45B7D1", selected: false },
+          { id: "friends", name: "Bạn bè", color: "#96CEB4", selected: false },
+          {
+            id: "later",
+            name: "Trả lời sau",
+            color: "#FFEEAD",
+            selected: false,
+          },
+        ]}
+        onLabelSelect={(labelId) => {
+          console.log(
+            "Selected label:",
+            labelId,
+            "for conversation:",
+            selectedConversation
+          );
+          setIsLabelModalOpen(false);
+        }}
+        onManageLabels={() => {
+          console.log("Manage labels clicked");
+          setIsLabelModalOpen(false);
+        }}
+      />
+
+      <NotificationModal
+        isOpen={isNotificationModalOpen}
+        onClose={() => setIsNotificationModalOpen(false)}
+        onSelect={(duration) => {
+          console.log(
+            "Selected notification duration:",
+            duration,
+            "for conversation:",
+            selectedConversation
+          );
+        }}
+      />
+
+      <AutoDeleteModal
+        isOpen={isAutoDeleteModalOpen}
+        onClose={() => setIsAutoDeleteModalOpen(false)}
+        onSelect={(duration) => {
+          console.log(
+            "Selected auto-delete duration:",
+            duration,
+            "for conversation:",
+            selectedConversation
+          );
         }}
       />
     </div>

--- a/src/components/chat/modals/AutoDeleteModal.tsx
+++ b/src/components/chat/modals/AutoDeleteModal.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+interface AutoDeleteModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (duration: string) => void;
+}
+
+const AutoDeleteModal: React.FC<AutoDeleteModalProps> = ({
+  isOpen,
+  onClose,
+  onSelect,
+}) => {
+  if (!isOpen) return null;
+
+  const options = [
+    { id: '1d', label: '1 ngày' },
+    { id: '7d', label: '7 ngày' },
+    { id: '14d', label: '14 ngày' },
+    { id: 'never', label: 'Không bao giờ' },
+  ];
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div 
+        className="bg-white rounded-lg shadow-xl w-96 max-w-md"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="p-4">
+          <div className="flex justify-between items-center mb-4">
+            <h3 className="text-lg font-semibold text-gray-900">Tin nhắn tự xóa</h3>
+            <button
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-500"
+            >
+              <span className="sr-only">Đóng</span>
+              <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          <div className="space-y-2">
+            {options.map((option) => (
+              <button
+                key={option.id}
+                className="w-full p-3 text-left text-sm text-gray-700 hover:bg-gray-100 rounded-lg transition-colors duration-150"
+                onClick={() => {
+                  onSelect(option.id);
+                  onClose();
+                }}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AutoDeleteModal;

--- a/src/components/chat/modals/LabelModal.tsx
+++ b/src/components/chat/modals/LabelModal.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTag } from '@fortawesome/free-solid-svg-icons';
+
+interface LabelModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  labels: Array<{
+    id: string;
+    name: string;
+    color: string;
+    selected: boolean;
+  }>;
+  onLabelSelect: (labelId: string) => void;
+  onManageLabels: () => void;
+}
+
+const LabelModal: React.FC<LabelModalProps> = ({
+  isOpen,
+  onClose,
+  labels,
+  onLabelSelect,
+  onManageLabels,
+}) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div 
+        className="bg-white rounded-lg shadow-xl w-96 max-w-md"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="p-4">
+          <div className="flex justify-between items-center mb-4">
+            <h3 className="text-lg font-semibold text-gray-900">Phân loại</h3>
+            <button
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-500"
+            >
+              <span className="sr-only">Đóng</span>
+              <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+          
+          <div className="max-h-[400px] overflow-y-auto">
+            <div className="px-1 py-2 font-bold text-gray-600">
+              <span>Theo thẻ phân loại</span>
+            </div>
+            
+            {labels.map((label) => (
+              <div 
+                key={label.id} 
+                className="flex items-center p-2 hover:bg-gray-100 rounded cursor-pointer my-1"
+                onClick={() => onLabelSelect(label.id)}
+              >
+                <div className="mr-3">
+                  <div className="flex items-center justify-center">
+                    <svg width="24" height="24" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <rect 
+                        x="5.25" 
+                        y="5.25" 
+                        width="14.5" 
+                        height="14.5" 
+                        rx="2.25" 
+                        fill={label.selected ? label.color : "white"} 
+                        stroke="#ccc" 
+                        strokeWidth="1.5"
+                      />
+                      {label.selected && (
+                        <path 
+                          d="M9 12.5L11.5 15L16 10" 
+                          stroke="white" 
+                          strokeWidth="2" 
+                          strokeLinecap="round" 
+                          strokeLinejoin="round"
+                        />
+                      )}
+                    </svg>
+                  </div>
+                </div>
+                <div className="mr-2" style={{ color: label.color }}>
+                  <FontAwesomeIcon icon={faTag} />
+                </div>
+                <div className="truncate flex-1 text-gray-700">{label.name}</div>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-4 border-t border-gray-200 pt-4">
+            <button
+              onClick={onManageLabels}
+              className={`w-full p-2 text-center rounded-full ${labels.some(l => l.selected) ? 'bg-blue-100 text-blue-600 font-medium' : 'text-blue-500 hover:bg-gray-100'}`}
+            >
+              Quản lý thẻ phân loại
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LabelModal;

--- a/src/components/chat/modals/NotificationModal.tsx
+++ b/src/components/chat/modals/NotificationModal.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+interface NotificationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (duration: string) => void;
+}
+
+const NotificationModal: React.FC<NotificationModalProps> = ({
+  isOpen,
+  onClose,
+  onSelect,
+}) => {
+  if (!isOpen) return null;
+
+  const options = [
+    { id: '1h', label: 'Trong 1 giờ' },
+    { id: '4h', label: 'Trong 4 giờ' },
+    { id: '8am', label: 'Cho đến 8:00 AM' },
+    { id: 'indefinite', label: 'Cho đến khi được mở lại' },
+  ];
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div 
+        className="bg-white rounded-lg shadow-xl w-96 max-w-md"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="p-4">
+          <div className="flex justify-between items-center mb-4">
+            <h3 className="text-lg font-semibold text-gray-900">Tắt thông báo</h3>
+            <button
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-500"
+            >
+              <span className="sr-only">Đóng</span>
+              <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          <div className="space-y-2">
+            {options.map((option) => (
+              <button
+                key={option.id}
+                className="w-full p-3 text-left text-sm text-gray-700 hover:bg-gray-100 rounded-lg transition-colors duration-150"
+                onClick={() => {
+                  onSelect(option.id);
+                  onClose();
+                }}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NotificationModal;


### PR DESCRIPTION
Introduce three new modals (`LabelModal`, `NotificationModal`, and `AutoDeleteModal`) to handle label assignment, notification settings, and auto-delete configurations for chat conversations. These modals are integrated into the chat list menu, providing a more structured and user-friendly way to manage conversation settings.