### PR TITLE
fix(api): close updateGroupAvatar function properly

### DIFF
--- a/src/api/API.ts
+++ b/src/api/API.ts
@@ -2521,6 +2521,8 @@ export const updateGroupAvatar = async (
     }
 
     throw new Error("Không thể cập nhật ảnh nhóm. Vui lòng thử lại sau.");
+  }
+};
 
 /**
  * Sets co-owners for a group conversation


### PR DESCRIPTION
- Added missing closing brace to the updateGroupAvatar function in API.ts to ensure proper function closure and prevent potential runtime errors.