### PR TITLE
refactor(chat): clean up ChatArea component by removing unused imports

### DIFF
--- a/src/components/chat/chatArea/ChatArea.tsx
+++ b/src/components/chat/chatArea/ChatArea.tsx
@@ -1,22 +1,15 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import {
-  Input,
   Button,
   message,
   Alert,
   Empty,
   Spin,
-  Tooltip,
   Menu
 } from "antd";
 import {
-  SendOutlined,
   ReloadOutlined,
   DownOutlined,
-  SmileOutlined,
-  PictureOutlined,
-  FileOutlined,
-  FileImageOutlined,
   DeleteOutlined,
   UndoOutlined,
   CopyOutlined,
@@ -40,15 +33,12 @@ import {
   getPinnedMessages,
   getSpecificMessage,
   replyMessage,
-  forwardImageMessage,
 } from "../../../api/API";
 import { useLanguage } from "../../../features/auth/context/LanguageContext";
 import { DisplayMessage } from "../../../features/chat/types/chatTypes";
 import { useConversationContext } from "../../../features/chat/context/ConversationContext";
-import data from "@emoji-mart/data";
-import Picker from "@emoji-mart/react";
+// import data from "@emoji-mart/data";
 import socketService from "../../../services/socketService";
-import FileUploader from "./FileUploader";
 import PinnedMessages from "./PinnedMessages";
 import MessageDisplay from "./MessageDisplay";
 import ChatInputArea from "./ChatInputArea";


### PR DESCRIPTION
- Removed unused imports including Input, Tooltip, and emoji-related components to streamline the ChatArea code.
- Commented out the emoji data import to reduce unnecessary dependencies while maintaining the option for future use.
- Enhanced overall readability and maintainability of the ChatArea component.